### PR TITLE
Telloのカメラ画像をSDカードに記録するロジックを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ M5を起動すると、自動で[Tello](https://www.ryzerobotics.com/jp/tello)�
 * [Unit ASR カスタムファームウェア](https://github.com/MRSa/GokigenOSDN_documents/tree/main/miscellaneous/M5/UnitASR)
 * [M5StickC用TF(SD) HAT(Switch Science)](https://ssci.to/9551)
 * [M5StickC用TF(SD) HAT(サポートページ)](https://github.com/rin-ofumi/m5stickc_sd_hat)
+* [M5stick CPlus & CPlus2 SD Backpack](https://github.com/ATOMNFT/M5stick-CPlus-SD-Backpack/tree/main)
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ M5を起動すると、自動で[Tello](https://www.ryzerobotics.com/jp/tello)�
 
 ### カスタムファームウェア
 
-* [V1.05(May.03, 2025)](https://github.com/MRSa/GokigenOSDN_documents/blob/main/miscellaneous/M5/UnitASR/jx_ci_03t_firmware_v105.bin)
+* [V1.06(May.04, 2025)](https://github.com/MRSa/GokigenOSDN_documents/blob/main/miscellaneous/M5/UnitASR/jx_ci_03t_firmware_v106.bin)
 
 ----
 
@@ -69,6 +69,8 @@ M5を起動すると、自動で[Tello](https://www.ryzerobotics.com/jp/tello)�
 * [Unit ASR ファームウェアフラッシングツール](https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/635/CI-03T_Serial_burning_software_V3.7.3.zip)
 * [Stamp ISP](https://docs.m5stack.com/ja/module/StampISP)
 * [Unit ASR カスタムファームウェア](https://github.com/MRSa/GokigenOSDN_documents/tree/main/miscellaneous/M5/UnitASR)
+* [M5StickC用TF(SD) HAT(Switch Science)](https://ssci.to/9551)
+* [M5StickC用TF(SD) HAT(サポートページ)](https://github.com/rin-ofumi/m5stickc_sd_hat)
 
 ----
 

--- a/TelloMoveM5.ino
+++ b/TelloMoveM5.ino
@@ -31,17 +31,21 @@ bool showErrorMessage;
 File streamFile;
 uint64_t cardSize;
 
-#define MAX_STREAM_BUFFER 36
-#define STREAM_BUFFER_SIZE 2048  //  > 1460(bytes.)
+#define MAX_STREAM_BUFFER 46
+#define STREAM_BUFFER_SIZE 1600  //  > 1460(bytes.)
 int currentBufferIndex;
 int readBufferIndex;
 uint64_t writeDataSize = 0;
+uint64_t writeBlocks = 0;
 byte streamBuffer[MAX_STREAM_BUFFER][STREAM_BUFFER_SIZE];
 int streamBufferSize[MAX_STREAM_BUFFER];
 
 enum { spi_sck = 0, spi_miso = 36, spi_mosi = 26, spi_ss = -1 };
 //#define HSPI_CLK 1500000
-#define HSPI_CLK 2500000
+//#define HSPI_CLK 2000000
+//#define HSPI_CLK 2500000
+//#define HSPI_CLK 3000000
+#define HSPI_CLK 3500000
 //#define HSPI_CLK 4000000
 SPIClass SPI_EXT = SPIClass(HSPI);
 
@@ -419,17 +423,17 @@ void movieEndHandler()
     displayMessage("録画終了", TFT_WHITE);
 
     Serial.print("Total Write Bytes: ");
-    Serial.println(writeDataSize);
+    Serial.print(writeDataSize);
+    Serial.print("  Write count: ");
+    Serial.println(writeBlocks);
     writeDataSize = 0;
+    writeBlocks = 0;
 }
 
 void receiveHandler()
 {
-    Serial.println("A command received!");
-    M5.Display.setCursor(0, 0);
-    M5.Lcd.fillScreen(TFT_BLACK);
-    M5.Lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-    M5.Display.println("(命令受信)");
+    Serial.println("Not support command received!");
+    displayMessage("(命令受信)", TFT_LIGHTGREY);
 }
 
 void checkBoardType()
@@ -720,6 +724,7 @@ void writeStreamData()
                     readBufferIndex++;
                 }
                 writeDataSize = writeDataSize + dataSize;
+                writeBlocks = writeBlocks + 1;
 
                 // ------ 書き込みデータのログ出力
                 //char message[64];
@@ -732,7 +737,7 @@ void writeStreamData()
             if (!showErrorMessage)
             {
                 char msg[96];
-                sprintf(msg, " rIdx:%d cIdx:%d size:%lld", readBufferIndex, currentBufferIndex, writeDataSize);
+                sprintf(msg, " rIdx:%d cIdx:%d size:%lld cnt:%lld", readBufferIndex, currentBufferIndex, writeDataSize, writeBlocks);
                 Serial.print("FILE OPEN Failure...");
                 Serial.println(msg);
             }
@@ -771,6 +776,7 @@ void setup()
     currentBufferIndex = 0;
     readBufferIndex = 0;
     writeDataSize = 0;
+    writeBlocks = 0;
     currentSpeed = 100;
 
     for (int i = 0; i < MAX_STREAM_BUFFER; i++)

--- a/TelloMoveM5.ino
+++ b/TelloMoveM5.ino
@@ -16,6 +16,7 @@ AsyncUDP udpStatus2;
 
 int batteryRemainM5;
 int batteryRemainTello;
+int currentSpeed;
 char commandMessageBuffer[256];
 
 // ==========================================================
@@ -241,6 +242,55 @@ void ccw90Handler()
     sendCommandToTello("ccw 90");
 }
 
+void sendSpeedCommand()
+{
+    char cmd[16];
+    char disp[24];
+    sprintf(disp, "速度 %d", currentSpeed);
+    sprintf(cmd, "speed %d", currentSpeed);
+    displayMessage(disp, TFT_WHITE);
+    sendCommandToTello(cmd);
+}
+
+
+void incSpeedHandler()
+{
+    currentSpeed = currentSpeed + 20;
+    if (currentSpeed > 100)
+    {
+        currentSpeed = 100;
+    }
+    sendSpeedCommand();
+}
+
+void decSpeedHandler()
+{
+    currentSpeed = currentSpeed - 20;
+    if (currentSpeed < 10)
+    {
+        currentSpeed = 10;
+    }
+    sendSpeedCommand();
+}
+
+void maxSpeedHandler()
+{
+    currentSpeed = 100;
+    sendSpeedCommand();
+}
+
+void midSpeedHandler()
+{
+    currentSpeed = 55;
+    sendSpeedCommand();
+}
+
+void minSpeedHandler()
+{
+    currentSpeed = 10;
+    sendSpeedCommand();
+}
+
 void emergencyHandler()
 {
     displayMessage("緊急停止!", TFT_ORANGE);
@@ -282,11 +332,11 @@ void prepareUnitASR()
     asr.addCommandWord(0x30, "ok",receiveHandler);
     asr.addCommandWord(0x31, "hi_ASR",receiveHandler);
     asr.addCommandWord(0x32, "hello",receiveHandler);
-    asr.addCommandWord(0x40, "increase_speed",receiveHandler);
-    asr.addCommandWord(0x41, "decrease_speed",receiveHandler);
-    asr.addCommandWord(0x42, "maximum_speed",receiveHandler);
-    asr.addCommandWord(0x43, "medium_speed",receiveHandler);
-    asr.addCommandWord(0x44, "minimum_speed",receiveHandler);
+    asr.addCommandWord(0x40, "increase_speed",incSpeedHandler);
+    asr.addCommandWord(0x41, "decrease_speed",decSpeedHandler);
+    asr.addCommandWord(0x42, "maximum_speed",maxSpeedHandler);
+    asr.addCommandWord(0x43, "medium_speed",midSpeedHandler);
+    asr.addCommandWord(0x44, "minimum_speed",minSpeedHandler);
     asr.addCommandWord(0x45, "fw_version",receiveHandler);
     asr.addCommandWord(0x46, "out_finished",receiveHandler);
     asr.addCommandWord(0x47, "out_started",receiveHandler);
@@ -323,6 +373,7 @@ void prepareUnitASR()
     asr.addCommandWord(0x67, "movie_end",receiveHandler);
     asr.addCommandWord(0x68, "status",receiveHandler);
     asr.addCommandWord(0x69, "time",receiveHandler);
+    asr.addCommandWord(0x6a, "remain",receiveHandler);
     asr.addCommandWord(0x71, "up 70",up40Handler);
     asr.addCommandWord(0x72, "down 70",down40Handler);
     asr.addCommandWord(0x73, "right 70",right40Handler);
@@ -346,7 +397,12 @@ void prepareUnitASR()
     asr.addCommandWord(0x95, "out_hour",receiveHandler);
     asr.addCommandWord(0x96, "out_second",receiveHandler);
     asr.addCommandWord(0x97, "out_minute",receiveHandler);
+    asr.addCommandWord(0x98, "out_remain",receiveHandler);
     asr.addCommandWord(0x99, "emergency",emergencyHandler);
+    asr.addCommandWord(0x9a, "out_time",receiveHandler);
+    asr.addCommandWord(0x9b, "out_speed",receiveHandler);
+    asr.addCommandWord(0x9c, "out_height",receiveHandler);
+    asr.addCommandWord(0x9d, "out_temp",receiveHandler);
     asr.addCommandWord(0xfe, "announce",receiveHandler);
     asr.addCommandWord(0xff, "hi_m_five",receiveHandler);
 }
@@ -398,6 +454,8 @@ void setup()
 
     batteryRemainM5 = M5.Power.getBatteryLevel();
     batteryRemainTello = -1;
+
+    currentSpeed = 100;
 
     // ----- LED(RED) OFF : for M5StickC Plus
     pinMode(GPIO_NUM_10, OUTPUT);


### PR DESCRIPTION
M5StickC Plus に [M5StickC用TF(SD) HAT](https://www.switch-science.com/products/9551) を接続して、Telloからのカメラ画像を録画できるようにする。
